### PR TITLE
Store props items using their full name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-api-documenter",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "React API documentation generator",
   "bin": {
     "react-api-documenter": "./bin.js"

--- a/src/api/getApiItems.ts
+++ b/src/api/getApiItems.ts
@@ -61,7 +61,7 @@ const accumulate = (acc: ApiItems, item: ApiItem, ignorePattern?: RegExp) => {
       }
     } else if (isInterface(item)) {
       if (isInterpretedAsProps(item)) {
-        acc.props[effectiveName.slice(0, -5)] = item;
+        acc.props[effectiveName] = item;
       } else {
         acc.types[effectiveName] = item;
       }

--- a/src/output/getMarkdownForComponent.ts
+++ b/src/output/getMarkdownForComponent.ts
@@ -15,7 +15,7 @@ export const getMarkdownForComponent = ({
 }: MarkdownGetterArguments): string => {
   let markdown = `## ${name}\n\n`;
   const component = items.components[name];
-  const props = items.props[name];
+  const props = items.props[`${name}Props`];
 
   markdown += getDescription({
     configuration,


### PR DESCRIPTION
Fixes #11 

Now:
![image](https://user-images.githubusercontent.com/2352621/124302977-df3a0700-db2f-11eb-86e1-ccc730dc32f8.png)

Improving on the assumption that `Component` has an interface `ComponentProps`. This assumption is not always true though and further improvements are required.