### PR TITLE
Include inherited members

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-api-documenter",
-  "version": "0.0.14",
+  "version": "0.0.17",
   "description": "React API documentation generator",
   "bin": {
     "react-api-documenter": "./bin.js"

--- a/src/output/getInterfaceMembers.ts
+++ b/src/output/getInterfaceMembers.ts
@@ -1,0 +1,33 @@
+import { ApiInterface, ApiItem } from "@microsoft/api-extractor-model";
+import {merge, keyBy} from "lodash";
+import { ApiItems } from "../api/getApiItems";
+import { isInterface } from "../api/isInterface";
+
+function _getInterfaceMembers(item: ApiInterface, items: ApiItems, membersAccumulator: {[name: string]: ApiItem})  {
+
+    const parentTypes = item.extendsTypes;
+
+    if (parentTypes.length > 0) {
+        parentTypes.forEach(parentType => {
+            const extendedTypeReferenceIndex = parentType.excerpt.tokens.findIndex(({kind}) => kind === "Reference");
+            const extendedTypeReference = parentType.excerpt.tokens[extendedTypeReferenceIndex];
+            const extendedApiItem = items.props[extendedTypeReference.text] || items.types[extendedTypeReference.text];
+            if (extendedApiItem && isInterface(extendedApiItem)) {
+                _getInterfaceMembers(extendedApiItem, items, membersAccumulator);
+            }    
+        })
+    }
+
+    merge(membersAccumulator, keyBy(item.members, "name"));
+}
+
+/**
+ * Returns an array of all of `item`'s own and inherited members.
+ */
+export function getInterfaceMembers(item: ApiInterface, items: ApiItems) : ApiItem[] {
+    const membersAccumulator: {[name: string]: ApiItem} = {};
+
+     _getInterfaceMembers(item, items, membersAccumulator);
+
+    return Object.values(membersAccumulator);
+}

--- a/src/output/getInterfaceTable.ts
+++ b/src/output/getInterfaceTable.ts
@@ -19,6 +19,7 @@ import {
 } from "@microsoft/tsdoc";
 import { ApiItems } from "../api/getApiItems";
 import { createParagraphForTypeExcerpt } from "./createParagraphForTypeExcerpt";
+import { getInterfaceMembers } from "./getInterfaceMembers";
 import { IndentedTableCell } from "./IndentedTableCell";
 
 const createTitleCell = (
@@ -127,7 +128,9 @@ export const getInterfaceTable = (
     headerTitles: ["Method", "Description"],
   });
 
-  for (const apiMember of item.members) {
+  const members =  getInterfaceMembers(item, items);
+
+  for (const apiMember of members) {
     switch (apiMember.kind) {
       case "ConstructSignature":
       case "MethodSignature": {

--- a/src/output/getMarkdownForComponent.ts
+++ b/src/output/getMarkdownForComponent.ts
@@ -1,5 +1,6 @@
 import { ApiPropertySignature } from "@microsoft/api-extractor-model";
 import { getDescription } from "./getDescription";
+import { getInterfaceMembers } from "./getInterfaceMembers";
 import { getInterfaceTable } from "./getInterfaceTable";
 import { MarkdownGetterArguments } from "./output.types";
 
@@ -27,7 +28,7 @@ export const getMarkdownForComponent = ({
 <${name}
 ${
   props
-    ? props.members
+    ? getInterfaceMembers(props, items)
         .map((prop: ApiPropertySignature) => `\t${prop.name}={${prop.name}}`)
         .join("\n")
     : "\t{...}"


### PR DESCRIPTION
This changes adds inherited interface members. It allows to enrich the description of props and types, when they exist as pure `ApiInterface`.
It does not understand type aliases yet nor does it compute more complex inheritances such as those based on `Omit` or `Pick`.

After/Before
![image](https://user-images.githubusercontent.com/2352621/124823795-97581d00-df3f-11eb-8570-cb93d6bcbcbf.png)
