### PR TITLE
Restore EOL scheme in bin file + remove broken links to props

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-api-documenter",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "description": "React API documentation generator",
   "bin": {
     "react-api-documenter": "./bin.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-api-documenter",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "description": "React API documentation generator",
   "bin": {
     "react-api-documenter": "./bin.js"

--- a/src/debug.ts
+++ b/src/debug.ts
@@ -1,3 +1,3 @@
 import { generateMarkdown } from "./generateMarkdown";
 
-generateMarkdown(".input", ".output");
+generateMarkdown(".input", ".output", /^_?Icon/);

--- a/src/getLinkPath.ts
+++ b/src/getLinkPath.ts
@@ -9,7 +9,6 @@ const fileNames = [
   "hooks",
   "types",
   "variables",
-  "props",
 ];
 
 export const getLinkPath = (


### PR DESCRIPTION
To work on circleci, `bin.js` must be in unix format.
Also removing links to inexisting prop file. Better classification of props so that they are featured in `types.md`  and linkable is soon to be added.