### PR TITLE
Include props in types

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-api-documenter",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "description": "React API documentation generator",
   "bin": {
     "react-api-documenter": "./bin.js"

--- a/src/api/getApiItems.ts
+++ b/src/api/getApiItems.ts
@@ -62,9 +62,8 @@ const accumulate = (acc: ApiItems, item: ApiItem, ignorePattern?: RegExp) => {
     } else if (isInterface(item)) {
       if (isInterpretedAsProps(item)) {
         acc.props[effectiveName] = item;
-      } else {
-        acc.types[effectiveName] = item;
       }
+      acc.types[effectiveName] = item;
     } else if (isTypeAlias(item)) {
       acc.types[effectiveName] = item;
     }


### PR DESCRIPTION
This classifies props as types as well as props.

This has 2 beneficial effects:
- Props not paired with a component solely by name now have an existence in the documentation
- Props can be reached by link from any point of the documentation.