### PR TITLE
Exclude paired Props from the "types" page

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-api-documenter",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "description": "React API documentation generator",
   "bin": {
     "react-api-documenter": "./bin.js"

--- a/src/api/getApiItems.ts
+++ b/src/api/getApiItems.ts
@@ -11,7 +11,6 @@ import {
 import { isInterpretedAsError } from "./isInterpretedAsError";
 import { isInterpretedAsHook } from "./isInterpretedAsHook";
 import { isInterpretedAsComponent } from "./isInterpretedAsComponent";
-import { isInterpretedAsProps } from "./isInterpretedAsProps";
 import { isInterpretedAsContextProvider } from "./isInterpretedAsContextProvider";
 import { isClass } from "./isClass";
 import { isFunction } from "./isFunction";
@@ -28,7 +27,6 @@ export interface ApiItems {
   hooks: { [name: string]: ApiFunction };
   types: { [name: string]: ApiInterface | ApiTypeAlias };
   variables: { [name: string]: ApiVariable };
-  props: { [name: string]: ApiInterface };
 }
 
 const accumulate = (acc: ApiItems, item: ApiItem, ignorePattern?: RegExp) => {
@@ -60,9 +58,6 @@ const accumulate = (acc: ApiItems, item: ApiItem, ignorePattern?: RegExp) => {
         acc.variables[effectiveName] = item;
       }
     } else if (isInterface(item)) {
-      if (isInterpretedAsProps(item)) {
-        acc.props[effectiveName] = item;
-      }
       acc.types[effectiveName] = item;
     } else if (isTypeAlias(item)) {
       acc.types[effectiveName] = item;
@@ -89,7 +84,6 @@ export const getApiItems = (
     hooks: {},
     types: {},
     variables: {},
-    props: {},
   };
 
   accumulate(acc, api, ignorePattern);

--- a/src/generateMarkdown.ts
+++ b/src/generateMarkdown.ts
@@ -43,10 +43,6 @@ export const generateMarkdown = async (
 
   await Promise.all(
     Object.keys(items).map((key: keyof ApiItems) => {
-      if (key === "props") {
-        // We don't generate a dedicated page for props: they are inlined with their corresponding Components.
-        return Promise.resolve();
-      }
       const markdownPage = getMarkdownPage({
         configuration,
         items,

--- a/src/getLinkPath.ts
+++ b/src/getLinkPath.ts
@@ -1,4 +1,5 @@
 import { ApiItems } from "./api/getApiItems";
+import { isPropsTypeWithMatchingComponent } from "./output/isPropsTypeWithMatchingComponent";
 
 const fileNames = [
   "classes",
@@ -21,5 +22,13 @@ export const getLinkPath = (
     return undefined;
   }
 
+  if (fileName === "types") {
+    if (isPropsTypeWithMatchingComponent(name, items)) {
+      // Found a matching component where the props are documented, hence linking to the components file.
+      return `./components#${name.toLowerCase()}`;
+    } else {
+      return `./types#${name.toLowerCase()}`;
+    }
+  }
   return `./${fileName}#${name.toLowerCase()}`;
 };

--- a/src/output/getInterfaceMembers.ts
+++ b/src/output/getInterfaceMembers.ts
@@ -1,33 +1,42 @@
 import { ApiInterface, ApiItem } from "@microsoft/api-extractor-model";
-import {merge, keyBy} from "lodash";
+import { merge, keyBy } from "lodash";
 import { ApiItems } from "../api/getApiItems";
 import { isInterface } from "../api/isInterface";
 
-function _getInterfaceMembers(item: ApiInterface, items: ApiItems, membersAccumulator: {[name: string]: ApiItem})  {
+function _getInterfaceMembers(
+  item: ApiInterface,
+  items: ApiItems,
+  membersAccumulator: { [name: string]: ApiItem }
+) {
+  const parentTypes = item.extendsTypes;
 
-    const parentTypes = item.extendsTypes;
+  if (parentTypes.length > 0) {
+    parentTypes.forEach((parentType) => {
+      const extendedTypeReferenceIndex = parentType.excerpt.tokens.findIndex(
+        ({ kind }) => kind === "Reference"
+      );
+      const extendedTypeReference =
+        parentType.excerpt.tokens[extendedTypeReferenceIndex];
+      const extendedApiItem = items.types[extendedTypeReference.text];
+      if (extendedApiItem && isInterface(extendedApiItem)) {
+        _getInterfaceMembers(extendedApiItem, items, membersAccumulator);
+      }
+    });
+  }
 
-    if (parentTypes.length > 0) {
-        parentTypes.forEach(parentType => {
-            const extendedTypeReferenceIndex = parentType.excerpt.tokens.findIndex(({kind}) => kind === "Reference");
-            const extendedTypeReference = parentType.excerpt.tokens[extendedTypeReferenceIndex];
-            const extendedApiItem = items.props[extendedTypeReference.text] || items.types[extendedTypeReference.text];
-            if (extendedApiItem && isInterface(extendedApiItem)) {
-                _getInterfaceMembers(extendedApiItem, items, membersAccumulator);
-            }    
-        })
-    }
-
-    merge(membersAccumulator, keyBy(item.members, "name"));
+  merge(membersAccumulator, keyBy(item.members, "name"));
 }
 
 /**
  * Returns an array of all of `item`'s own and inherited members.
  */
-export function getInterfaceMembers(item: ApiInterface, items: ApiItems) : ApiItem[] {
-    const membersAccumulator: {[name: string]: ApiItem} = {};
+export function getInterfaceMembers(
+  item: ApiInterface,
+  items: ApiItems
+): ApiItem[] {
+  const membersAccumulator: { [name: string]: ApiItem } = {};
 
-     _getInterfaceMembers(item, items, membersAccumulator);
+  _getInterfaceMembers(item, items, membersAccumulator);
 
-    return Object.values(membersAccumulator);
+  return Object.values(membersAccumulator);
 }

--- a/src/output/getMarkdownForComponent.ts
+++ b/src/output/getMarkdownForComponent.ts
@@ -1,7 +1,9 @@
 import { ApiPropertySignature } from "@microsoft/api-extractor-model";
+import { isTypeAlias } from "../api/isTypeAlias";
 import { getDescription } from "./getDescription";
 import { getInterfaceMembers } from "./getInterfaceMembers";
 import { getInterfaceTable } from "./getInterfaceTable";
+import { getTypeDescription } from "./getTypeDescription";
 import { MarkdownGetterArguments } from "./output.types";
 
 /**
@@ -16,7 +18,8 @@ export const getMarkdownForComponent = ({
 }: MarkdownGetterArguments): string => {
   let markdown = `## ${name}\n\n`;
   const component = items.components[name];
-  const props = items.props[`${name}Props`];
+  const propsName = `${name}Props`;
+  const props = items.types[propsName];
 
   markdown += getDescription({
     configuration,
@@ -27,7 +30,7 @@ export const getMarkdownForComponent = ({
   markdown += `\`\`\`jsx
 <${name}
 ${
-  props
+  props && !isTypeAlias(props)
     ? getInterfaceMembers(props, items)
         .map((prop: ApiPropertySignature) => `\t${prop.name}={${prop.name}}`)
         .join("\n")
@@ -38,11 +41,20 @@ ${
 
 ${
   props
-    ? getInterfaceTable(props, {
-        configuration,
-        items,
-        markdownEmitter,
-      })
+    ? `### ${propsName}\n\n${
+        isTypeAlias(props)
+          ? getTypeDescription({
+              markdownEmitter,
+              configuration,
+              type: props,
+              items,
+            })
+          : getInterfaceTable(props, {
+              configuration,
+              items,
+              markdownEmitter,
+            })
+      }`
     : ""
 }`;
 

--- a/src/output/getMarkdownPage.ts
+++ b/src/output/getMarkdownPage.ts
@@ -1,4 +1,3 @@
-import { MarkdownDocumenter } from "@microsoft/api-documenter/lib/documenters/MarkdownDocumenter";
 import { MarkdownEmitter } from "@microsoft/api-documenter/lib/markdown/MarkdownEmitter";
 import { TSDocConfiguration } from "@microsoft/tsdoc";
 import { ApiItems } from "../api/getApiItems";
@@ -40,18 +39,16 @@ sidebar_label: ${labels[key]}
   \n`;
 
   // Props are documented alongside their corresponding Components.
-  if (key !== "props") {
-    Object.keys(items[key]).forEach((name) => {
-      markdown += `${getMardownSection({
-        configuration,
-        items,
-        key,
-        markdownEmitter,
-        name,
-        packageCanonicalReference,
-      })}\n\n`;
-    });
-  }
+  Object.keys(items[key]).forEach((name) => {
+    markdown += `${getMardownSection({
+      configuration,
+      items,
+      key,
+      markdownEmitter,
+      name,
+      packageCanonicalReference,
+    })}\n\n`;
+  });
 
   return markdown;
 };

--- a/src/output/getTypeDescription.ts
+++ b/src/output/getTypeDescription.ts
@@ -1,0 +1,35 @@
+import { MarkdownEmitter } from "@microsoft/api-documenter/lib/markdown/MarkdownEmitter";
+import { ApiTypeAlias } from "@microsoft/api-extractor-model";
+import { StringBuilder, TSDocConfiguration } from "@microsoft/tsdoc";
+import { ApiItems } from "../api/getApiItems";
+import { createParagraphForTypeExcerpt } from "./createParagraphForTypeExcerpt";
+import { indent } from "./indent";
+
+export function getTypeDescription({
+  items,
+  markdownEmitter,
+  type,
+  configuration,
+}: {
+  items: ApiItems;
+  type: ApiTypeAlias;
+  markdownEmitter: MarkdownEmitter;
+  configuration: TSDocConfiguration;
+}) {
+  const excerpt = markdownEmitter
+    .emit(
+      new StringBuilder(),
+      createParagraphForTypeExcerpt(type.typeExcerpt, {
+        configuration,
+        items,
+      }),
+      { configuration }
+    )
+    .trim();
+  return excerpt.includes("\\|")
+    ? `- ${excerpt
+        .split("\\|")
+        .map((bit) => indent(bit))
+        .join("\n-")}`
+    : indent(excerpt);
+}

--- a/src/output/isPropsTypeWithMatchingComponent.ts
+++ b/src/output/isPropsTypeWithMatchingComponent.ts
@@ -1,0 +1,16 @@
+import { ApiItems } from "../api/getApiItems";
+
+/**
+ * Returns `true` if the name denotes a props type `FooProps` for which there exist a component `<Foo />`.
+ */
+export function isPropsTypeWithMatchingComponent(
+  name: string,
+  items: ApiItems
+) {
+  const matcherResult = name.match(/(?<componentName>.*)Props$/);
+  return (
+    matcherResult &&
+    matcherResult.groups.componentName &&
+    items.components[matcherResult.groups.componentName]
+  );
+}


### PR DESCRIPTION
Props paired to a component are now described in the "components" page whether they are an interface or a type alias. A linkable anchor has been added and reference to these will correctly link to this page if they exist.

These will no longer appear in the "types" page, but the unpaired props remain which is good.

![image](https://user-images.githubusercontent.com/2352621/126691113-3927496e-c126-4603-b112-8e05a6379ba8.png)

![image](https://user-images.githubusercontent.com/2352621/126691239-ebf37311-ca38-4725-a069-143ec660e4bf.png)

Props not paired are still found under "types".

To improve the components page, users of the product should be encouraged to avoid anonymous interfaces and to name "type" props to match the component.