### PR TITLE
Do not return undefined when string is expected

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-api-documenter",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "description": "React API documentation generator",
   "bin": {
     "react-api-documenter": "./bin.js"

--- a/src/output/getMarkdownForType.ts
+++ b/src/output/getMarkdownForType.ts
@@ -18,7 +18,7 @@ export const getMarkdownForType = ({
   if (isPropsTypeWithMatchingComponent(name, items)) {
     // Do not document this type in the `types` page if it is a props type with a component associated to it.
     // These are already documented next to their component.
-    return;
+    return "";
   }
   let markdown = `## ${name}\n\n`;
   const type = items.types[name];


### PR DESCRIPTION
Markdown would contain the `undefined` token where we would expect nothing to be added to the markdown.
This fixes that.
