### PR TITLE
Wrong extension resolving

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-api-documenter",
-  "version": "0.0.24",
+  "version": "0.0.25",
   "description": "React API documentation generator",
   "bin": {
     "react-api-documenter": "./bin.js"

--- a/src/output/getInterfaceMembers.ts
+++ b/src/output/getInterfaceMembers.ts
@@ -12,12 +12,7 @@ function _getInterfaceMembers(
 
   if (parentTypes.length > 0) {
     parentTypes.forEach((parentType) => {
-      const extendedTypeReferenceIndex = parentType.excerpt.tokens.findIndex(
-        ({ kind }) => kind === "Reference"
-      );
-      const extendedTypeReference =
-        parentType.excerpt.tokens[extendedTypeReferenceIndex];
-      const extendedApiItem = items.types[extendedTypeReference.text];
+      const extendedApiItem = items.types[parentType.excerpt.text.trim()];
       if (extendedApiItem && isInterface(extendedApiItem)) {
         _getInterfaceMembers(extendedApiItem, items, membersAccumulator);
       }


### PR DESCRIPTION
fixes #22 

Resolving parent types is actually simpler than previously thought and makes the process more accurate.