### PR TITLE
Use tokenRange.startIndex to improve parent type resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-api-documenter",
-  "version": "0.0.25",
+  "version": "0.0.26",
   "description": "React API documentation generator",
   "bin": {
     "react-api-documenter": "./bin.js"

--- a/src/output/getInterfaceMembers.ts
+++ b/src/output/getInterfaceMembers.ts
@@ -12,7 +12,12 @@ function _getInterfaceMembers(
 
   if (parentTypes.length > 0) {
     parentTypes.forEach((parentType) => {
-      const extendedApiItem = items.types[parentType.excerpt.text.trim()];
+      const extendedApiItem =
+        items.types[
+          parentType.excerpt.tokens[
+            parentType.excerpt.tokenRange.startIndex
+          ].text.trim()
+        ];
       if (extendedApiItem && isInterface(extendedApiItem)) {
         _getInterfaceMembers(extendedApiItem, items, membersAccumulator);
       }


### PR DESCRIPTION
The text of a parentType can have generics which will prevent the resolution within the `apiItems`. Using the `tokenRange.startIndex` ensures that we isolate the relevant part of the type.