### PR TITLE
Option for link base url

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-api-documenter",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "description": "React API documentation generator",
   "bin": {
     "react-api-documenter": "./bin.js"

--- a/src/MarkdownEmitterWithLinks.ts
+++ b/src/MarkdownEmitterWithLinks.ts
@@ -7,6 +7,7 @@ import { DocTable } from "@microsoft/api-documenter/lib/nodes/DocTable";
 import { DocTableCell } from "@microsoft/api-documenter/lib/nodes/DocTableCell";
 import { ApiModel } from "@microsoft/api-extractor-model";
 import { DocLinkTag, DocNode } from "@microsoft/tsdoc";
+import { link } from "fs-extra";
 import { ApiItems } from "./api/getApiItems";
 import { getLinkPath } from "./getLinkPath";
 import { indent } from "./output/indent";
@@ -16,10 +17,15 @@ import { IndentedTableCell } from "./output/IndentedTableCell";
 // MarkdownEmitterWithLinks resolves react-api-documenter links: one page for a group of items (e.g. functions or Components) then one anchor per item.
 export class MarkdownEmitterWithLinks extends CustomMarkdownEmitter {
   private _apiItems: ApiItems;
+  private _linkBaseUrl?: string;
 
-  public constructor(apiModel: ApiModel, apiItems: ApiItems) {
+  public constructor(
+    apiModel: ApiModel,
+    apiItems: ApiItems,
+    linkBaseUrl?: string
+  ) {
     super(apiModel);
-
+    this._linkBaseUrl = linkBaseUrl;
     this._apiItems = apiItems;
   }
 
@@ -89,7 +95,9 @@ export class MarkdownEmitterWithLinks extends CustomMarkdownEmitter {
             this.writeNode(cell.content, context, false);
             writer.write = originalWrite.bind(writer);
 
-            const formattedCellContent = isIndented ? indent(cellContent, {characterBreakingLine}) : cellContent;
+            const formattedCellContent = isIndented
+              ? indent(cellContent, { characterBreakingLine })
+              : cellContent;
             writer.write(formattedCellContent);
 
             writer.write(" |");
@@ -115,7 +123,11 @@ export class MarkdownEmitterWithLinks extends CustomMarkdownEmitter {
       docLinkTag.codeDestination.memberReferences[0].memberIdentifier
         .identifier;
 
-    const linkPath = getLinkPath(linkedItemName, this._apiItems);
+    const linkPath = getLinkPath(
+      linkedItemName,
+      this._apiItems,
+      this._linkBaseUrl
+    );
 
     if (!linkPath) {
       context.writer.write(linkedItemName);

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -14,9 +14,15 @@ command(
     const inputFolder = getArg(args, "--input-folder");
     const outputFolder = getArg(args, "--output-folder");
     const ignoreString = getArg(args, "--ignore-pattern");
+    const linkBaseUrl = getArg(args, "--link-base-url");
     const ignorePattern = ignoreString ? new RegExp(ignoreString) : undefined;
 
-    await generateMarkdown(inputFolder, outputFolder, ignorePattern);
+    await generateMarkdown(
+      inputFolder,
+      outputFolder,
+      ignorePattern,
+      linkBaseUrl
+    );
   }
 )
   .demandCommand(1, "")

--- a/src/debug.ts
+++ b/src/debug.ts
@@ -1,3 +1,3 @@
 import { generateMarkdown } from "./generateMarkdown";
 
-generateMarkdown(".input", ".output", /^_?Icon/);
+generateMarkdown(".input", ".output", /^_?Icon/, "/docs/api");

--- a/src/generateMarkdown.ts
+++ b/src/generateMarkdown.ts
@@ -15,7 +15,8 @@ const configuration = initConfiguration();
 export const generateMarkdown = async (
   inputFolder: string,
   outputFolder: string,
-  ignorePattern?: RegExp
+  ignorePattern?: RegExp,
+  linkBaseUrl?: string
 ) => {
   const fileNames = await readdir(inputFolder);
   const apiFileName = fileNames.find((fileName) =>
@@ -37,7 +38,11 @@ export const generateMarkdown = async (
 
   const items = getApiItems(apiPackage, ignorePattern);
 
-  const markdownEmitter = new MarkdownEmitterWithLinks(apiModel, items);
+  const markdownEmitter = new MarkdownEmitterWithLinks(
+    apiModel,
+    items,
+    linkBaseUrl
+  );
 
   await ensureDir(outputFolder);
 
@@ -49,6 +54,7 @@ export const generateMarkdown = async (
         key,
         markdownEmitter,
         packageCanonicalReference: apiPackage.canonicalReference.toString(),
+        linkBaseUrl,
       });
       return writeFile(path.resolve(outputFolder, `${key}.md`), markdownPage);
     })

--- a/src/getLinkPath.ts
+++ b/src/getLinkPath.ts
@@ -14,7 +14,8 @@ const fileNames = [
 
 export const getLinkPath = (
   name: string,
-  items: ApiItems
+  items: ApiItems,
+  linkBaseUrl?: string
 ): string | undefined => {
   const fileName = fileNames.find((kind) => items[kind][name] !== undefined);
 
@@ -25,10 +26,10 @@ export const getLinkPath = (
   if (fileName === "types") {
     if (isPropsTypeWithMatchingComponent(name, items)) {
       // Found a matching component where the props are documented, hence linking to the components file.
-      return `./components#${name.toLowerCase()}`;
+      return `${linkBaseUrl || "."}/components#${name.toLowerCase()}`;
     } else {
-      return `./types#${name.toLowerCase()}`;
+      return `${linkBaseUrl || "."}/types#${name.toLowerCase()}`;
     }
   }
-  return `./${fileName}#${name.toLowerCase()}`;
+  return `${linkBaseUrl || "."}/${fileName}#${name.toLowerCase()}`;
 };

--- a/src/output/createParagraphForTypeExcerpt.ts
+++ b/src/output/createParagraphForTypeExcerpt.ts
@@ -15,7 +15,12 @@ const appendExcerptWithHyperlinks = (
   {
     configuration,
     items,
-  }: { configuration: TSDocConfiguration; items: ApiItems }
+    linkBaseUrl,
+  }: {
+    configuration: TSDocConfiguration;
+    items: ApiItems;
+    linkBaseUrl?: string;
+  }
 ): void => {
   for (const token of excerpt.spannedTokens) {
     const linkedItemName: string = token.text.replace(/[\r\n]+/g, " ");
@@ -27,7 +32,7 @@ const appendExcerptWithHyperlinks = (
           configuration,
           tagName: "@link",
           linkText: linkedItemName,
-          urlDestination: getLinkPath(linkedItemName, items),
+          urlDestination: getLinkPath(linkedItemName, items, linkBaseUrl),
         })
       );
     } else {
@@ -44,7 +49,12 @@ export const createParagraphForTypeExcerpt = (
   {
     configuration,
     items,
-  }: { configuration: TSDocConfiguration; items: ApiItems }
+    linkBaseUrl,
+  }: {
+    configuration: TSDocConfiguration;
+    items: ApiItems;
+    linkBaseUrl?: string;
+  }
 ): DocParagraph => {
   const paragraph: DocParagraph = new DocParagraph({ configuration });
 
@@ -53,7 +63,11 @@ export const createParagraphForTypeExcerpt = (
       new DocPlainText({ configuration, text: "(not declared)" })
     );
   } else {
-    appendExcerptWithHyperlinks(paragraph, excerpt, { configuration, items });
+    appendExcerptWithHyperlinks(paragraph, excerpt, {
+      configuration,
+      items,
+      linkBaseUrl,
+    });
   }
 
   return paragraph;

--- a/src/output/getArgumentsTable.ts
+++ b/src/output/getArgumentsTable.ts
@@ -25,10 +25,12 @@ export const getArgumentsTable = (
     configuration,
     items,
     markdownEmitter,
+    linkBaseUrl,
   }: {
     configuration: TSDocConfiguration;
     items: ApiItems;
     markdownEmitter: MarkdownEmitter;
+    linkBaseUrl?: string;
   }
 ): string => {
   const docSection = new DocSection({ configuration });
@@ -62,6 +64,7 @@ export const getArgumentsTable = (
             createParagraphForTypeExcerpt(apiParameter.parameterTypeExcerpt, {
               configuration,
               items,
+              linkBaseUrl,
             }),
           ],
           { isIndented: true, characterBreakingLine: ";" }
@@ -88,6 +91,7 @@ export const getArgumentsTable = (
       createParagraphForTypeExcerpt(apiFunction.returnTypeExcerpt, {
         configuration,
         items,
+        linkBaseUrl,
       })
     );
 

--- a/src/output/getInterfaceTable.ts
+++ b/src/output/getInterfaceTable.ts
@@ -42,7 +42,12 @@ const createPropertyTypeCell = (
   {
     configuration,
     items,
-  }: { configuration: TSDocConfiguration; items: ApiItems }
+    linkBaseUrl,
+  }: {
+    configuration: TSDocConfiguration;
+    items: ApiItems;
+    linkBaseUrl?: string;
+  }
 ): IndentedTableCell => {
   const section: DocSection = new DocSection({ configuration });
 
@@ -51,6 +56,7 @@ const createPropertyTypeCell = (
       createParagraphForTypeExcerpt(apiItem.propertyTypeExcerpt, {
         configuration,
         items,
+        linkBaseUrl,
       })
     );
   }
@@ -105,10 +111,12 @@ export const getInterfaceTable = (
     configuration,
     items,
     markdownEmitter,
+    linkBaseUrl,
   }: {
     configuration: TSDocConfiguration;
     items: ApiItems;
     markdownEmitter: MarkdownEmitter;
+    linkBaseUrl?: string;
   }
 ): string => {
   const docSection = new DocSection({ configuration });
@@ -128,7 +136,7 @@ export const getInterfaceTable = (
     headerTitles: ["Method", "Description"],
   });
 
-  const members =  getInterfaceMembers(item, items);
+  const members = getInterfaceMembers(item, items);
 
   for (const apiMember of members) {
     switch (apiMember.kind) {
@@ -147,7 +155,11 @@ export const getInterfaceTable = (
           eventsTable.addRow(
             new DocTableRow({ configuration }, [
               createTitleCell(apiMember, { configuration }),
-              createPropertyTypeCell(apiMember, { configuration, items }),
+              createPropertyTypeCell(apiMember, {
+                configuration,
+                items,
+                linkBaseUrl,
+              }),
               createDescriptionCell(apiMember, { configuration }),
             ])
           );
@@ -155,7 +167,11 @@ export const getInterfaceTable = (
           propertiesTable.addRow(
             new DocTableRow({ configuration }, [
               createTitleCell(apiMember, { configuration }),
-              createPropertyTypeCell(apiMember, { configuration, items }),
+              createPropertyTypeCell(apiMember, {
+                configuration,
+                items,
+                linkBaseUrl,
+              }),
               createDescriptionCell(apiMember, { configuration }),
             ])
           );

--- a/src/output/getMarkdownForClass.ts
+++ b/src/output/getMarkdownForClass.ts
@@ -17,7 +17,7 @@ export const getMarkdownForClass = ({
   items,
   markdownEmitter,
   name,
-  packageCanonicalReference,
+  linkBaseUrl,
 }: MarkdownGetterArguments): string => {
   let markdown = `## ${name}\n\n`;
   const item = items.classes[name];
@@ -42,6 +42,7 @@ export const getMarkdownForClass = ({
       configuration,
       items,
       markdownEmitter,
+      linkBaseUrl,
     });
     markdown += "\n\n";
   }
@@ -71,6 +72,7 @@ export const getMarkdownForClass = ({
       markdownEmitter,
       items,
       configuration,
+      linkBaseUrl,
     });
 
     const remarkSections = getRemarksSection(item, {

--- a/src/output/getMarkdownForComponent.ts
+++ b/src/output/getMarkdownForComponent.ts
@@ -14,7 +14,7 @@ export const getMarkdownForComponent = ({
   items,
   markdownEmitter,
   name,
-  packageCanonicalReference,
+  linkBaseUrl,
 }: MarkdownGetterArguments): string => {
   let markdown = `## ${name}\n\n`;
   const component = items.components[name];
@@ -53,6 +53,7 @@ ${
               configuration,
               items,
               markdownEmitter,
+              linkBaseUrl,
             })
       }`
     : ""

--- a/src/output/getMarkdownForFunction.ts
+++ b/src/output/getMarkdownForFunction.ts
@@ -29,7 +29,12 @@ ${name}(${indent(
  */
 export const getMarkdownForFunction = (
   item: ApiFunction,
-  { configuration, items, markdownEmitter }: MarkdownGetterArguments
+  {
+    configuration,
+    items,
+    markdownEmitter,
+    linkBaseUrl,
+  }: MarkdownGetterArguments
 ): string => {
   let markdown = `## ${item.name}\n\n`;
 
@@ -45,6 +50,7 @@ export const getMarkdownForFunction = (
     configuration,
     items,
     markdownEmitter,
+    linkBaseUrl,
   });
 
   const remarkSections = getRemarksSection(item, {

--- a/src/output/getMarkdownForType.ts
+++ b/src/output/getMarkdownForType.ts
@@ -14,6 +14,7 @@ export const getMarkdownForType = ({
   items,
   markdownEmitter,
   name,
+  linkBaseUrl,
 }: MarkdownGetterArguments): string => {
   if (isPropsTypeWithMatchingComponent(name, items)) {
     // Do not document this type in the `types` page if it is a props type with a component associated to it.
@@ -35,6 +36,7 @@ export const getMarkdownForType = ({
       items,
       type,
       markdownEmitter,
+      linkBaseUrl,
     });
   } else {
     // Actual atomic type
@@ -42,6 +44,7 @@ export const getMarkdownForType = ({
       configuration,
       items,
       markdownEmitter,
+      linkBaseUrl,
     })}`;
   }
 

--- a/src/output/getMarkdownPage.ts
+++ b/src/output/getMarkdownPage.ts
@@ -24,12 +24,14 @@ export const getMarkdownPage = ({
   key,
   packageCanonicalReference,
   markdownEmitter,
+  linkBaseUrl,
 }: {
   configuration: TSDocConfiguration;
   items: ApiItems;
   key: keyof ApiItems;
   packageCanonicalReference: string;
   markdownEmitter: MarkdownEmitter;
+  linkBaseUrl: string;
 }): string => {
   // This top comment is helpful for Docusaurus integration
   let markdown = `---
@@ -47,6 +49,7 @@ sidebar_label: ${labels[key]}
       markdownEmitter,
       name,
       packageCanonicalReference,
+      linkBaseUrl,
     });
     if (markdownForItem && markdownForItem.trim().length > 0) {
       markdown += `${markdownForItem}\n\n`;

--- a/src/output/getTypeDescription.ts
+++ b/src/output/getTypeDescription.ts
@@ -10,11 +10,13 @@ export function getTypeDescription({
   markdownEmitter,
   type,
   configuration,
+  linkBaseUrl,
 }: {
   items: ApiItems;
   type: ApiTypeAlias;
   markdownEmitter: MarkdownEmitter;
   configuration: TSDocConfiguration;
+  linkBaseUrl?: string;
 }) {
   const excerpt = markdownEmitter
     .emit(
@@ -22,6 +24,7 @@ export function getTypeDescription({
       createParagraphForTypeExcerpt(type.typeExcerpt, {
         configuration,
         items,
+        linkBaseUrl,
       }),
       { configuration }
     )

--- a/src/output/output.types.ts
+++ b/src/output/output.types.ts
@@ -8,4 +8,5 @@ export interface MarkdownGetterArguments {
   markdownEmitter: MarkdownEmitter;
   packageCanonicalReference: string;
   name: string;
+  linkBaseUrl?: string;
 }


### PR DESCRIPTION
This adds an option to the command line for clients to supply a base url prefix to be added everytime the documenter generates a link. This makes it possible to use absolute links in docusaurus (related to the main host name still) which can help solving issues around urls with trailing slashes.