### PR TITLE
Change markdown file names to kebab-case

### DIFF
--- a/src/getLinkPath.ts
+++ b/src/getLinkPath.ts
@@ -6,7 +6,7 @@ const fileNames = [
   "errors",
   "functions",
   "components",
-  "contextProviders",
+  "context-providers",
   "hooks",
   "types",
   "variables",


### PR DESCRIPTION
[This PR in ActiveUI](https://github.com/activeviam/activeui/pull/1836) suggests that the markdown files generated with this module must be named in kebab-case.