### PR TITLE
Revamp deprecated message + support for interface member

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-api-documenter",
-  "version": "0.0.31",
+  "version": "0.0.32",
   "description": "React API documentation generator",
   "bin": {
     "react-api-documenter": "./bin.js"

--- a/src/initConfiguration.ts
+++ b/src/initConfiguration.ts
@@ -50,12 +50,15 @@ export const initConfiguration = (): TSDocConfiguration => {
   configuration.docNodeManager.registerAllowableChildren("EmphasisSpan", [
     "PlainText",
     "SoftBreak",
+    "CodeSpan",
   ]);
 
   configuration.docNodeManager.registerAllowableChildren("Section", [
     "Heading",
     "NoteBox",
     "Table",
+    "EmphasisSpan",
+    "PlainText",
   ]);
 
   configuration.docNodeManager.registerAllowableChildren("Paragraph", [

--- a/src/output/getDescription.ts
+++ b/src/output/getDescription.ts
@@ -1,5 +1,4 @@
 import { MarkdownEmitter } from "@microsoft/api-documenter/lib/markdown/MarkdownEmitter";
-import { DocNoteBox } from "@microsoft/api-documenter/lib/nodes/DocNoteBox";
 import { ApiDocumentedItem, ApiItem } from "@microsoft/api-extractor-model";
 import {
   DocComment,
@@ -31,17 +30,18 @@ export const getDescription = ({
 
     if (tsdocComment) {
       if (tsdocComment.deprecatedBlock) {
-        docSection.appendNode(
-          new DocNoteBox({ configuration }, [
-            new DocParagraph({ configuration }, [
-              new DocPlainText({
-                configuration,
-                text: "Warning: This is obsolete. ",
-              }),
-            ]),
-            ...tsdocComment.deprecatedBlock.content.nodes,
-          ])
-        );
+        docSection.appendNodes([
+          new DocParagraph({ configuration }, [
+            new DocPlainText({
+              configuration,
+              text: ":::caution Deprecated",
+            }),
+          ]),
+          ...tsdocComment.deprecatedBlock.content.nodes,
+          new DocParagraph({ configuration }, [
+            new DocPlainText({ configuration, text: ":::" }),
+          ]),
+        ]);
       }
 
       for (const node of tsdocComment.summarySection.nodes) {


### PR DESCRIPTION
`@deprecated` elements were handled in some places but not all.

This adds support for interface table members when they are flagged as deprecated. It also use a better looking [admonition ](https://docusaurus.io/docs/markdown-features/admonitions) over the doc note when outputting a block is allowed.

![image](https://user-images.githubusercontent.com/2352621/143659609-ec38792b-c5cc-4061-8742-d2c050d8b828.png)

Inside an interface table where having a block or a line break is not allowed, I've opted to mark the method name and the deprecation message in italic. Alternatively, we could also have a separate table for all deprecated attributes. The formatting options are however limited from inside a table.

![image](https://user-images.githubusercontent.com/2352621/143659615-cfa9c136-59ea-428b-a49d-7a6a9891bfbb.png)


