### PR TITLE
UI-6157 - Fix indentation

### DIFF
--- a/src/output/indent.test.ts
+++ b/src/output/indent.test.ts
@@ -1,7 +1,7 @@
 import { indent } from "./indent";
 
 describe("indent", () => {
-  it("indents `input`, escaping special characters", () => {
+  it("indents `input`, escaping line returns, tabs and whitespaces", () => {
     expect(
       indent(`
 {

--- a/src/output/indent.test.ts
+++ b/src/output/indent.test.ts
@@ -1,7 +1,7 @@
 import { indent } from "./indent";
 
 describe("indent", () => {
-  it("indents `input`", () => {
+  it("indents `input`, escaping special characters", () => {
     expect(
       indent(`
 {
@@ -10,17 +10,11 @@ b: 1,
 c: 1
 },
 d: 4
-}    
+}
 `)
     ).toMatchInlineSnapshot(`
       "
-      {
-      	a: {
-      		b: 1,
-      		c: 1
-      	},
-      	d: 4
-      }    
+      {<br />&nbsp;&nbsp;<br />&nbsp;&nbsp;a: {<br />&nbsp;&nbsp;&nbsp;&nbsp;<br />&nbsp;&nbsp;&nbsp;&nbsp;b: 1,<br />&nbsp;&nbsp;&nbsp;&nbsp;c: 1<br />&nbsp;&nbsp;<br />},<br />d: 4<br /><br />}
       "
     `);
   });

--- a/src/output/indent.ts
+++ b/src/output/indent.ts
@@ -20,8 +20,7 @@ export const indent = (
   const end = input.slice(indexOfLastOpeningBracked + 1);
 
   const characterBreakingLine = options?.characterBreakingLine || ";";
-  const isEscaped =
-    options?.isEscaped === undefined ? true : options?.isEscaped;
+  const isEscaped = options?.isEscaped ?? true;
 
   const middleWithLineReturns = middle
     .replace(/\{/g, "{\n")
@@ -49,7 +48,7 @@ export const indent = (
     }
     indentedMiddle += char;
     if (char === `\n` && indentationLevel > 0) {
-      indentedMiddle += `${isEscaped ? "&nbsp;&nbsp" : "  "}`.repeat(
+      indentedMiddle += `${isEscaped ? "&nbsp;&nbsp;" : "  "}`.repeat(
         indentationLevel
       );
     }


### PR DESCRIPTION
Preliminary work for the upgrade to Docusaurus 3 https://github.com/activeviam/atoti-ui/pull/4631
See the documentation in the artifacts of that PR, and look at `CellSetTableProps` for example => some `&nbsp` instances are unexpectedly visible.
This PR should fix it.
To be fair, I don't know why we didn't have the bug before in the first place, as there is evidently a missing semicolon.