### PR TITLE
Explicit line return before remarks

### DIFF
--- a/src/output/getMarkdownForClass.ts
+++ b/src/output/getMarkdownForClass.ts
@@ -79,7 +79,7 @@ export const getMarkdownForClass = ({
     });
 
     if (remarkSections) {
-      markdown += "\n";
+      markdown += "\n\n";
       markdown += remarkSections;
     }
 
@@ -89,7 +89,7 @@ export const getMarkdownForClass = ({
     });
 
     if (throwsSections) {
-      markdown += "\n";
+      markdown += "\n\n";
       markdown += throwsSections;
     }
 

--- a/src/output/getMarkdownForFunction.ts
+++ b/src/output/getMarkdownForFunction.ts
@@ -53,7 +53,7 @@ export const getMarkdownForFunction = (
   });
 
   if (remarkSections) {
-    markdown += "\n";
+    markdown += "\n\n";
     markdown += remarkSections;
   }
 

--- a/src/output/getMarkdownForType.ts
+++ b/src/output/getMarkdownForType.ts
@@ -51,7 +51,7 @@ export const getMarkdownForType = ({
   });
 
   if (remarkSections) {
-    markdown += "\n";
+    markdown += "\n\n";
     markdown += remarkSections;
   }
 


### PR DESCRIPTION
Fixes https://github.com/activeviam/atoti-ui/pull/4631#pullrequestreview-2000389974

Whether the extra line return is needed depends on the Markdown flavor/implementation: it indeed seems to be [needed for CommonMark](https://spec.commonmark.org/dingus/) which is the opt-in Markdown flavor used in Docusaurus 3, and in https://markdownlivepreview.com/, but it's not needed in https://dotmd-editor.vercel.app/ https://dillinger.io/, https://stackedit.io/app.

To be fair, I think it makes sense to have it anyway: if I was writing the markdown myself I would naturally have put the extra line return explicitly so that visually `Remarks` is a different paragraph.