### PR TITLE
Fix components declared as variables.

### DIFF
--- a/src/api/getApiItems.ts
+++ b/src/api/getApiItems.ts
@@ -46,6 +46,8 @@ const accumulate = (acc: ApiItems, item: ApiItem, ignorePattern?: RegExp) => {
     } else if (isFunction(item)) {
       if (isInterpretedAsHook(item)) {
         acc.hooks[effectiveName] = item;
+      } else if (isInterpretedAsComponent(item)) {
+        acc.components[effectiveName] = item;
       } else {
         acc.functions[effectiveName] = item;
       }

--- a/src/api/isInterpretedAsComponent.ts
+++ b/src/api/isInterpretedAsComponent.ts
@@ -5,7 +5,12 @@ import { isFunction } from "./isFunction";
  * Returns whether `item` is interpreted as a Component.
  */
 export const isInterpretedAsComponent = (item: ApiFunction | ApiVariable) => {
-  // Variable explicitely typed as a Component
+  const isHOC = item.name.startsWith("with");
+  if (isHOC) {
+    return false;
+  }
+
+  // Variable explicitly typed as a Component
   const isComponent = item.excerptTokens.some(
     (token) =>
       token.text === "FC" ||
@@ -14,16 +19,24 @@ export const isInterpretedAsComponent = (item: ApiFunction | ApiVariable) => {
       token.text === "MemoExoticComponent" ||
       token.text === "ForwardRefExoticComponent"
   );
-  
+
   if (isComponent) {
     return true;
   }
 
   if (item.excerptTokens.length > 0) {
-    const excerptTokensExcludingDefaultProps = item.excerptTokens.filter(token => token.text.indexOf("defaultProps") === -1);
-    const lastToken = excerptTokensExcludingDefaultProps[excerptTokensExcludingDefaultProps.length - 1];
+    const excerptTokensExcludingDefaultProps = item.excerptTokens.filter(
+      (token) => token.text.indexOf("defaultProps") === -1
+    );
+    const lastToken =
+      excerptTokensExcludingDefaultProps[
+        excerptTokensExcludingDefaultProps.length - 1
+      ];
     // Function returning a JSX.Element or ReactElement
-    return lastToken && (lastToken.text === "JSX.Element" || lastToken.text === "ReactElement");
+    return (
+      lastToken &&
+      (lastToken.text === "JSX.Element" || lastToken.text === "ReactElement")
+    );
   }
 
   return false;


### PR DESCRIPTION
In the new versions of @microsoft/api-extractor based on most recent versions of type script, components declared as variables are reported as functions rather than variables leading to some [components](https://github.com/activeviam/atoti-ui/blob/fc8a827cfc914678cbed602ea6e20a4e6c447d1a/packages/content-tree/src/ContentNodeIcon.tsx#L16) to be reported as function instead of components.